### PR TITLE
Vcash support

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,5 +1,5 @@
 Linux/OSX with GNU make:
-$ git clone https://github.com/WyseNynja/vanitygen.git
+$ git clone https://github.com/xCoreDev/vanitygen.git
 $ cd vanitygen
 $ sudo apt-get install build-essential libtool autotools-dev autoconf libssl-dev libdb-dev libdb++-dev libboost-all-dev libpcre3 libpcre3-dev automake
 $ make

--- a/README
+++ b/README
@@ -13,7 +13,7 @@ Vanitygen is written in C, and is provided in source code form and
 pre-built Win32 binaries.  At present, vanitygen can be built on Linux, 
 and requires the openssl and pcre libraries.
 
-Vanitygen can generate regular bitcoin addresses, namecoin addresses, 
+Vanitygen can generate regular bitcoin, namecoin, litecoin, vcash, 
 and testnet addresses.
 
 Vanitygen can search for exact prefixes or regular expression matches.  

--- a/oclvanitygen.c
+++ b/oclvanitygen.c
@@ -59,6 +59,7 @@ usage(const char *name)
 "-1            Stop after first match\n"
 "-L            Generate litecoin address\n"
 "-N            Generate namecoin address\n"
+"-V            Generate vcash address\n"
 "-T            Generate bitcoin testnet address\n"
 "-X <version>  Generate address with the given version\n"
 "-F <format>   Generate address with the given format (pubkey, compressed)\n"
@@ -75,7 +76,7 @@ usage(const char *name)
 "-t <threads>  Set target thread count per multiprocessor\n"
 "-g <x>x<y>    Set grid size\n"
 "-b <invsize>  Set modular inverse ops per thread\n"
-"-V            Enable kernel/OpenCL/hardware verification (SLOW)\n"
+"-K            Enable kernel/OpenCL/hardware verification (SLOW)\n"
 "-f <file>     File containing list of patterns, one per line\n"
 "              (Use \"-\" as the file name for stdin)\n"
 "-o <file>     Write pattern matches to <file>\n"
@@ -127,7 +128,7 @@ main(int argc, char **argv)
 	int i;
 
 	while ((opt = getopt(argc, argv,
-			     "vqik1LNTX:F:eE:p:P:d:w:t:g:b:VSh?f:o:s:D:")) != -1) {
+			     "vqik1LNVTX:F:eE:p:P:d:w:t:g:b:KSh?f:o:s:D:")) != -1) {
 		switch (opt) {
 		case 'v':
 			verbose = 2;
@@ -151,6 +152,10 @@ main(int argc, char **argv)
 		case 'N':
 			addrtype = 52;
 			privtype = 180;
+			break;
+		case 'V':
+			addrtype = 71;
+			privtype = 199;
 			break;
 		case 'T':
 			addrtype = 111;
@@ -225,7 +230,7 @@ main(int argc, char **argv)
 				return 1;
 			}
 			break;
-		case 'V':
+		case 'K':
 			verify_mode = 1;
 			break;
 		case 'S':

--- a/pattern.c
+++ b/pattern.c
@@ -1402,9 +1402,9 @@ vg_prefix_context_add_patterns(vg_context_t *vcp,
 			bw = "\"3\"";
 			break;
 		case 48:
-                        ats = "litecoin";
-                        bw = "\"L\"";
-                        break;
+			ats = "litecoin";
+			bw = "\"L\"";
+			break;
 		case 111:
 			ats = "testnet";
 			bw = "\"m\" or \"n\"";
@@ -1412,6 +1412,10 @@ vg_prefix_context_add_patterns(vg_context_t *vcp,
 		case 52:
 			ats = "namecoin";
 			bw = "\"M\" or \"N\"";
+			break;
+		case 71:
+			ats = "vcash";
+			bw = "\"V\"";
 			break;
 		default:
 			break;

--- a/vanitygen.c
+++ b/vanitygen.c
@@ -300,6 +300,7 @@ usage(const char *name)
 "-1            Stop after first match\n"
 "-L            Generate litecoin address\n"
 "-N            Generate namecoin address\n"
+"-V            Generate vcash address\n"
 "-T            Generate bitcoin testnet address\n"
 "-X <version>  Generate address with the given version\n"
 "-F <format>   Generate address with the given format (pubkey, compressed, script)\n"
@@ -350,7 +351,7 @@ main(int argc, char **argv)
 
 	int i;
 
-	while ((opt = getopt(argc, argv, "Lvqnrik1eE:P:NTX:F:t:h?f:o:s:")) != -1) {
+	while ((opt = getopt(argc, argv, "Lvqnrik1eE:P:VNTX:F:t:h?f:o:s:")) != -1) {
 		switch (opt) {
 		case 'c':
 		        compressed = 1;
@@ -385,6 +386,11 @@ main(int argc, char **argv)
 			addrtype = 48;
 			privtype = 176;
 			scriptaddrtype = -1;
+			break;
+		case 'V':
+			addrtype = 71;
+			privtype = 199;
+			scriptaddrtype = 8;
 			break;
 		case 'T':
 			addrtype = 111;


### PR DESCRIPTION
I changed the -V option to -K (Enable kernel/OpenCL/hardware verification) in oclvanitygen, so -V option is now dedicated to Vcash in both vanitygen & oclvanitygen.
